### PR TITLE
rwmem: Add a sig handler in case of bus access errors

### DIFF
--- a/rwmem/rwmem.cpp
+++ b/rwmem/rwmem.cpp
@@ -19,6 +19,7 @@
 
 #include <stdio.h>
 #include <unistd.h>
+#include <csignal>
 
 #include "rwmem.h"
 #include "helpers.h"
@@ -506,6 +507,18 @@ static void print_reg_matches(const RegisterFileData* rfd, const vector<RegMatch
 		else
 			printf("%s\n", m.rbd->name(rfd));
 	}
+ }
+
+ static void main_sigbus_handler(int sig)
+ {
+         /* just to remove "unused parameter" warnings ... */
+
+         fprintf(stderr, "\n\n!!! OUPS... MEMORY ERROR !!\n");
+         fprintf(stderr, "Are you sure that:\n");
+         fprintf(stderr, "    MEMORY ADDRESS IS VALID?\n");
+         fprintf(stderr, "    TARGETED MODULE IS CLOCKED?\n\n");
+
+         exit(-1);
 }
 
 int main(int argc, char **argv)
@@ -514,6 +527,9 @@ int main(int argc, char **argv)
 		rwmem_ini.load(string(getenv("HOME")) + "/.rwmem/rwmem.ini");
 	} catch(...) {
 	}
+
+	/* handler to catch bad access */
+	signal(SIGBUS, main_sigbus_handler);
 
 	load_opts_from_ini_pre();
 


### PR DESCRIPTION
In case of bus errors while directly accessing memory addresses that
are either invalid OR not clocked, generate an error so that people
dont go scratching their heads.

Signed-off-by: Nishanth Menon nm@ti.com
