### PR TITLE
include missing <cstdint>

### DIFF
--- a/librwmem/helpers.h
+++ b/librwmem/helpers.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <cerrno>
+#include <cstdint>
 #include <string>
 #include <vector>
 #include <string.h>


### PR DESCRIPTION
gcc 13 moved some includes around and as a result <cstdint> is no longer transitively included [1]. Explicitly include it for uint{32,64}_t.

[1] https://gcc.gnu.org/gcc-13/porting_to.html#header-dep-changes

Signed-off-by: Khem Raj <raj.khem@gmail.com>